### PR TITLE
feat: added safe set exp id

### DIFF
--- a/ml_instrumentation/Collector.py
+++ b/ml_instrumentation/Collector.py
@@ -42,6 +42,11 @@ class Collector:
         self._exp_id = id
         self._frame = -1
 
+    def safe_set_experiment_id(self, id: str | int):
+        if self._exp_id is None:
+            self._exp_id = id
+            self._frame = -1
+
     def get_current_experiment_id(self) -> str | int:
         assert self._exp_id is not None
         return self._exp_id


### PR DESCRIPTION
This is a potential way to deal with issue #5.

Added a function to be optionally used instead of `set_experiment_id`:

```
    def safe_set_experiment_id(self, id: str | int):
        if self._exp_id is None:
            self._exp_id = id
            self._frame = -1
```