### PR TITLE
test: ensure frame is correctly restored after serde

### DIFF
--- a/ml_instrumentation/Collector.py
+++ b/ml_instrumentation/Collector.py
@@ -46,6 +46,9 @@ class Collector:
         assert self._exp_id is not None
         return self._exp_id
 
+    def get_frame(self):
+        return self._frame
+
     def next_frame(self):
         self._frame += 1
 

--- a/tests/acceptance/test_Collector.py
+++ b/tests/acceptance/test_Collector.py
@@ -49,6 +49,8 @@ def test_collector1(collector_fixture, tmp_path, request):
     with open(tmp_path / 'chk.pkl', 'rb') as f:
         collector = pickle.load(f)
 
+    assert collector.get_frame() == (50_000 - 1)
+
     # execute the second half of the program
     expected_2 = simulate_run(
         collector,


### PR DESCRIPTION
Looking into #5 to understand where the issue is coming from. This test makes sure the frame is being restored correctly after (de)serialization.

Implicitly, this was already being tested by checking stored data against expected data after deserializing, but it seemed worthwhile to make the check explicit as well.