### PR TITLE
Jax callbacks

### DIFF
--- a/.github/workflows/main_benchmark.yml
+++ b/.github/workflows/main_benchmark.yml
@@ -19,15 +19,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-          cache: 'pip'
 
-      - name: Setup dependencies
-        run: |
-          python -m venv .venv
-          source .venv/bin/activate
-          pip install uv
-          uv pip compile --extra=dev pyproject.toml -o requirements.txt
-          uv pip sync requirements.txt
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - run: |
+          uv venv
+          uv sync
 
       - run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/main_benchmark.yml
+++ b/.github/workflows/main_benchmark.yml
@@ -25,7 +25,7 @@ jobs:
 
       - run: |
           uv venv
-          uv sync
+          uv sync --group=jax
 
       - run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/pr_benchmark.yml
+++ b/.github/workflows/pr_benchmark.yml
@@ -14,15 +14,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-          cache: 'pip'
 
-      - name: Setup dependencies
-        run: |
-          python -m venv .venv
-          source .venv/bin/activate
-          pip install uv
-          uv pip compile --extra=dev pyproject.toml -o requirements.txt
-          uv pip sync requirements.txt
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - run: |
+          uv venv
+          uv sync
 
       - run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/pr_benchmark.yml
+++ b/.github/workflows/pr_benchmark.yml
@@ -20,7 +20,7 @@ jobs:
 
       - run: |
           uv venv
-          uv sync
+          uv sync --group=jax
 
       - run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -24,7 +24,7 @@ jobs:
 
       - run: |
           uv venv
-          uv sync
+          uv sync --group=jax
 
       - run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -18,18 +18,17 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
       - run: |
-          python -m venv .venv
-          source .venv/bin/activate
-          pip install uv
-          uv pip compile --extra=dev pyproject.toml -o requirements.txt
-          uv pip sync requirements.txt
+          uv venv
+          uv sync
 
       - run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
 
-      - run: pytest tests/ --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml --cov=ml_instrumentation --cov-report=html:coverage/cov-${{ matrix.os }}-${{ matrix.python-version }}.html
+      - run: uv run pytest tests/ --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml --cov=ml_instrumentation --cov-report=html:coverage/cov-${{ matrix.os }}-${{ matrix.python-version }}.html
 
       - name: Upload pytest test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -17,7 +17,7 @@ jobs:
 
       - run: |
           uv venv
-          uv sync
+          uv sync --group=jax
 
       - run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -11,15 +11,13 @@ jobs:
       # setup the repository
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with:
-          cache: 'pip'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
       - run: |
-          python -m venv .venv
-          source .venv/bin/activate
-          pip install uv
-          uv pip compile --extra=dev pyproject.toml -o requirements.txt
-          uv pip sync requirements.txt
+          uv venv
+          uv sync
 
       - run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.pyc
 test.db
 test.py
+uv.lock

--- a/ml_instrumentation/Writer.py
+++ b/ml_instrumentation/Writer.py
@@ -194,7 +194,7 @@ class Writer:
         if name in self._built:
             return
 
-        cur.execute(f'CREATE TABLE "{name}"(frame INTEGER PRIMARY KEY ASC, id, measurement)')
+        cur.execute(f'CREATE TABLE "{name}"(frame INTEGER, id, measurement)')
         self._built.add(name)
 
     def _write_many(self, cur: sqlite3.Cursor, m: str, d: List[SqlPoint]):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,14 +36,17 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
+jax = [
+    "jax>=0.5.0",
+]
 dev = [
-    "pip",
-    "ruff",
-    "pytest",
-    "pytest-cov",
-    "pytest-benchmark",
-    "pyright",
-    "commitizen",
-    "pre-commit",
+    "commitizen>=4.2.1",
+    "pip>=25.0.1",
+    "pre-commit>=4.1.0",
+    "pyright>=1.1.393",
+    "pytest>=8.3.4",
+    "pytest-benchmark>=5.1.0",
+    "pytest-cov>=6.0.0",
+    "ruff>=0.9.5",
 ]

--- a/tests/integration/test_jax.py
+++ b/tests/integration/test_jax.py
@@ -1,0 +1,66 @@
+from functools import partial
+import jax
+import jax.experimental
+from ml_instrumentation.Collector import Collector
+from ml_instrumentation.Writer import SqlPoint
+
+def test_collector_jax_jit(basic_collector: Collector):
+    basic_collector.set_experiment_id(0)
+    basic_collector.next_frame()
+
+    @partial(jax.jit, static_argnums=(1,))
+    def f(x: jax.Array, collector: Collector):
+        y = 2 * x
+        y = y.dot(y)
+        collector.collect_jax('m1', y)
+        return y
+
+    x = jax.numpy.array([0, 1, 2, 3])
+    y = f(x, basic_collector)
+
+    assert y == 56
+    assert basic_collector.get('m1', 0) == [
+        SqlPoint(frame=0, id=0, measurement=56)
+    ]
+
+def test_collector_jax_grad(basic_collector: Collector):
+    basic_collector.set_experiment_id(0)
+    basic_collector.next_frame()
+
+    @partial(jax.jit, static_argnums=(1,))
+    @jax.grad
+    def f(x: jax.Array, collector: Collector):
+        y = 2 * x
+        y = y.dot(y)
+        collector.collect_jax('m1', y)
+        return y
+
+    x = jax.numpy.array([0, 1, 2, 3.])
+    f(x, basic_collector)
+
+    assert basic_collector.get('m1', 0) == [
+        SqlPoint(frame=0, id=0, measurement=56)
+    ]
+
+def test_collector_jax_vmap(basic_collector: Collector):
+    basic_collector.set_experiment_id(0)
+    basic_collector.next_frame()
+
+    @partial(jax.jit, static_argnums=(1,))
+    @partial(jax.vmap, in_axes=(0, None), out_axes=0)
+    def f(x: jax.Array, collector: Collector):
+        y = 2 * x
+        y = y.dot(y)
+        collector.collect_jax('m1', y)
+        return y
+
+    x = jax.numpy.array([
+        [0, 1, 2, 3.],
+        [1, 1, 2, 3.],
+    ])
+    f(x, basic_collector)
+
+    assert basic_collector.get('m1', 0) == [
+        SqlPoint(frame=0, id=0, measurement=56),
+        SqlPoint(frame=0, id=0, measurement=60),
+    ]


### PR DESCRIPTION
This PR adds the ability to call `collect` from within a jax jitted function. To disambiguate functionality, this introduces a new `collect_jax` function which will schedule a debug callback within jax (which won't interrupt program flow) and ensure no jax array's are stored in the Collector's internal memory.

The choice of `debug.callback` vs the seemingly more appropriate `experiment.io_callback` was due to a desire to support callbacks within `jax.grad`. It isn't immediately clear that this was the best choice --- there could be some unintended side-effects with some `collect` calls getting dropped. For now, this seems sufficiently sound, but will revisit after gaining some use cases.

Basic usage example (see tests for more):
```python
    @partial(jax.jit, static_argnums=(1,))
    def f(x: jax.Array, collector: Collector):
        y = 2 * x
        y = y.dot(y)
        collector.collect_jax('m1', y)
        return y
```