### PR TITLE
Add metadata storage and reading utilities

### DIFF
--- a/ml_instrumentation/Collector.py
+++ b/ml_instrumentation/Collector.py
@@ -18,6 +18,8 @@ class Collector:
         config: dict[str, Sampler | Ignore] | None = None,
         default: Identity | Ignore = identity,
         experiment_id: int | str | None = None,
+        low_watermark: int = 1024,
+        high_watermark: int = 2048,
     ):
         self._c = config or {}
 
@@ -29,8 +31,8 @@ class Collector:
         self._tmp_file = tmp_file
         self._writer = Writer(
             db_path=self._tmp_file,
-            low_watermark=1,
-            high_watermark=2048,
+            low_watermark=low_watermark,
+            high_watermark=high_watermark,
         )
 
         self._exp_id = experiment_id

--- a/ml_instrumentation/_utils/sqlite.py
+++ b/ml_instrumentation/_utils/sqlite.py
@@ -1,6 +1,52 @@
+from collections.abc import Iterable
+from typing import Any
 from sqlite3 import Cursor
+
 
 def get_tables(cur: Cursor) -> set[str]:
     cur.row_factory = None
     res = cur.execute("SELECT name FROM sqlite_master")
     return set(r[0] for r in res.fetchall())
+
+
+def make_table(cur: Cursor, name: str, columns: Iterable[str]):
+    cols = ', '.join(map(quote, columns))
+    cur.execute(f'CREATE TABLE {name}({cols})')
+
+
+def maybe_make_table(cur: Cursor, name: str, columns: Iterable[str]):
+    tables = get_tables(cur)
+
+    if name not in tables:
+        make_table(cur, name, columns)
+
+
+def get_cols(cur: Cursor, name: str):
+    res = cur.execute(f'PRAGMA table_info({name})')
+    rows = res.fetchall()
+
+    return set(r[1] for r in rows)
+
+
+def add_cols(cur: Cursor, columns: Iterable[str]):
+    columns = map(quote, columns)
+    for col in columns:
+        cur.execute(f'ALTER TABLE results ADD COLUMN {col}')
+
+
+def ensure_table_compatible(cur: Cursor, name: str, columns: Iterable[str]):
+    columns = set(columns)
+    current_cols = get_cols(cur, name)
+    needed_cols = columns - current_cols
+
+    if needed_cols:
+        add_cols(cur, needed_cols)
+
+
+def maybe_quote(v: Any):
+    if isinstance(v, str):
+        return quote(v)
+    return v
+
+def quote(s: str):
+    return f'"{s}"'

--- a/ml_instrumentation/metadata.py
+++ b/ml_instrumentation/metadata.py
@@ -1,0 +1,29 @@
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from filelock import FileLock
+
+import ml_instrumentation._utils.sqlite as sqlu
+
+def attach_metadata(db_path: str | Path, id: int | str, metadata: dict[str, Any]):
+    db_path = Path(db_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with FileLock(f'{db_path}.lock'):
+        con = sqlite3.connect(db_path)
+        cur = con.cursor()
+
+        metadata |= {'id': id}
+        cols = metadata.keys()
+        sqlu.maybe_make_table(cur, '_metadata_', cols)
+        sqlu.ensure_table_compatible(cur, '_metadata_', cols)
+
+        inserter = ', '.join(['?'] * len(cols))
+
+        header = ', '.join(map(sqlu.quote, cols))
+        query = f'INSERT INTO _metadata_ ({header}) VALUES ({inserter})'
+        print(query)
+        cur.execute(query, list(metadata.values()))
+        con.commit()
+        con.close()

--- a/ml_instrumentation/reader.py
+++ b/ml_instrumentation/reader.py
@@ -1,0 +1,54 @@
+from collections.abc import Iterable
+from functools import reduce
+from pathlib import Path
+from typing import Any
+import connectorx as cx
+import sqlite3
+
+import ml_instrumentation._utils.sqlite as sqlu
+
+
+def read_to_df(db_path: str | Path, metric: str, ids: Iterable[int] | None = None):
+    db_path = Path(db_path)
+
+    constraints = ''
+    if ids is not None:
+        str_ids = map(str, map(sqlu.maybe_quote, ids))
+        constraints = f'WHERE id IN ({",".join(str_ids)})'
+
+    query = f'SELECT * FROM {metric} {constraints}'
+    df = cx.read_sql(f'sqlite://{db_path}', query, partition_on='id', partition_num=4, return_type='polars')
+    df = df.rename({'measurement': metric})
+    return df
+
+
+def read_metrics(db_path: str | Path, metrics: Iterable[str], ids: Iterable[int] | None = None):
+    dfs = [read_to_df(db_path, metric, ids) for metric in metrics]
+    df = reduce(lambda df1, df2: df1.join(df2, how='full', on=['id', 'frame']), dfs)
+    return df
+
+
+def load_all_results(db_path: str | Path, metrics: Iterable[str] | None = None, ids: Iterable[int] | None = None):
+    con = sqlite3.connect(db_path)
+    cur = con.cursor()
+
+    tables = sqlu.get_tables(cur)
+    if metrics is None:
+        metrics = tables - {'_metadata_'}
+
+    df = read_metrics(db_path, metrics, ids)
+
+    if '_metadata_' not in tables:
+        return df
+
+    meta = cx.read_sql(f'sqlite://{db_path}', 'SELECT * FROM _metadata_', return_type='polars')
+    return df.join(meta, how='left', on=['id'])
+
+
+def get_run_ids(db_path: str | Path, params: dict[str, Any]):
+    constraints = ' AND '.join(
+        f'[{k}]={sqlu.maybe_quote(v)}' for k, v in params.items()
+    )
+
+    query = f'SELECT id FROM _metadata_ WHERE {constraints}'
+    return cx.read_sql(f'sqlite://{db_path}', query, return_type='polars')['id'].to_list()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ authors = [
 dependencies = [
     "numpy>=1.26,<=2.2.3",
     "filelock~=3.13",
+    "polars>=1.23.0",
+    "connectorx>=0.4.2",
+    "pyarrow>=19.0.1",
 ]
 requires-python = ">=3.10,<3.13"
 readme = "README.md"


### PR DESCRIPTION
Adds a simple metadata table (`_metadata_`) for storing a mapping from run_id to (hyperparams, seed, etc.).

Also adds a few utilities to read collected data into a pola.rs dataframe, compatible (but not coupled to) rl-evaluation.