### PR TITLE
refactor: generalize db backend to allow using alternative buffered writers

### DIFF
--- a/.github/workflows/main_benchmark.yml
+++ b/.github/workflows/main_benchmark.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/pr_benchmark.yml
+++ b/.github/workflows/pr_benchmark.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       # setup the repository

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -37,7 +37,7 @@ jobs:
       # setup the repository
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: 3.13
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 *.pyc
 test.db
 test.py
+**/*.egg-info
 uv.lock

--- a/ml_instrumentation/Collector.py
+++ b/ml_instrumentation/Collector.py
@@ -4,6 +4,7 @@ from typing import Any
 import jax.experimental
 from ml_instrumentation.Sampler import Sampler, Ignore, Identity, identity
 from ml_instrumentation.Writer import Writer, Point
+from ml_instrumentation.backends.sqlite import Sqlite
 
 try:
     import jax
@@ -30,7 +31,7 @@ class Collector:
 
         self._tmp_file = tmp_file
         self._writer = Writer(
-            db_path=self._tmp_file,
+            backend=Sqlite(self._tmp_file),
             low_watermark=low_watermark,
             high_watermark=high_watermark,
         )
@@ -177,11 +178,10 @@ class Collector:
             self.__dict__[k] = v
 
         self._writer = Writer(
-            db_path=self._tmp_file,
+            backend=Sqlite(self._tmp_file),
             low_watermark=1024,
             high_watermark=2048,
         )
 
         if state['data'] is not None:
-            self._writer._con.executescript(state['data'])
-            self._writer._init_db()
+            self._writer.load(state['data'])

--- a/ml_instrumentation/backends/base.py
+++ b/ml_instrumentation/backends/base.py
@@ -1,0 +1,39 @@
+from typing import Any, NamedTuple
+
+class SqlPoint(NamedTuple):
+    frame: int
+    id: int | str
+    measurement: Any
+
+
+class Point(NamedTuple):
+    exp_id: int | str
+    metric: str
+    frame: int
+    data: Any
+
+
+class BaseBackend:
+    def read_metric(self, metric: str, exp_id: int | str | None = None) -> list[SqlPoint]:
+        ...
+
+    def init_db(self) -> None:
+        ...
+
+    def dump(self) -> str:
+        ...
+
+    def load(self, data: Any) -> None:
+        ...
+
+    def close(self) -> None:
+        ...
+
+    def get_tables(self) -> set[str]:
+        ...
+
+    def merge(self, other: str) -> None:
+        ...
+
+    def write_many(self, points: dict[str, dict[int, Point]]) -> None:
+        ...

--- a/ml_instrumentation/backends/sqlite.py
+++ b/ml_instrumentation/backends/sqlite.py
@@ -1,0 +1,121 @@
+from pathlib import Path
+from typing import Any
+import filelock
+import logging
+import os
+import sqlite3
+from ml_instrumentation.backends.base import BaseBackend, Point, SqlPoint
+import ml_instrumentation._utils.sqlite as sqlu
+
+logger = logging.getLogger('ml-instrumentation')
+
+
+class Sqlite(BaseBackend):
+    def __init__(self, path: str | Path):
+        self._path = path
+        self._con = sqlite3.connect(path, check_same_thread=False)
+        self._con.row_factory = row_factory
+
+        self._built = set[str]()
+
+    # -----------
+    # -- Setup --
+    # -----------
+    def init_db(self):
+        if not os.path.exists(self._path) and self._path != ':memory:':
+            return
+
+        cur = self._con.cursor()
+        self._built |= sqlu.get_tables(cur)
+
+
+    def _setup_table(self, cur: sqlite3.Cursor, name: str):
+        if name in self._built:
+            return
+
+        cur.execute(f'CREATE TABLE "{name}"(frame INTEGER ASC, id, measurement)')
+        self._built.add(name)
+
+    # -------------
+    # -- Reading --
+    # -------------
+
+    def get_tables(self):
+        return self._built
+
+    def read_metric(self, metric: str, exp_id: int | str | None = None):
+        cond = ''
+        if exp_id is not None:
+            cond = f'WHERE id={sqlu.maybe_quote(exp_id)}'
+
+        cur = self._con.cursor()
+        try:
+            cur = cur.execute(f'SELECT * FROM "{metric}" {cond}')
+            res = cur.fetchall()
+        except sqlite3.OperationalError:
+            logger.warning(f'Specified metric/exp_id does not exist: <{metric}, {exp_id}>')
+            res = []
+
+        return res
+
+    # -------------
+    # -- Writing --
+    # -------------
+    def write_many(self, points: dict[str, dict[int, Point]]):
+        cur = self._con.cursor()
+        sql_d = {}
+        for m, sub in points.items():
+            sql_d[m] = [
+                SqlPoint(p.frame, p.exp_id, p.data) for p in sub.values()
+            ]
+
+        for m in sql_d:
+            self._setup_table(cur, m)
+            self._write_many(cur, m, sql_d[m])
+
+        self._con.commit()
+
+    def _write_many(self, cur: sqlite3.Cursor, m: str, d: list[SqlPoint]):
+        cur.executemany(f'INSERT INTO "{m}" (frame, id, measurement) VALUES (?,?,?)', d)
+
+    def merge(self, other: str):
+        with filelock.FileLock(f'{other}.lock'):
+            other_con = sqlite3.connect(other)
+
+            cur = self._con.cursor()
+            other_cur = other_con.cursor()
+            tables = sqlu.get_tables(cur)
+            other_tables = sqlu.get_tables(other_cur)
+
+            to_build = tables - other_tables
+            for table in to_build:
+                other_cur.execute(f'CREATE TABLE "{table}"(frame, id, measurement)')
+
+            other_con.close()
+
+            cur.execute(f'ATTACH DATABASE "{other}" AS other_db')
+            for table in tables:
+                cur.execute(f'INSERT INTO other_db.{table} SELECT * FROM {table}')
+
+            self._con.commit()
+            cur.execute('DETACH DATABASE other_db')
+            cur.close()
+
+    # ---------------
+    # -- Lifecycle --
+    # ---------------
+
+    def dump(self) -> str:
+        self._con.row_factory = None
+        return ''.join(self._con.iterdump())
+
+    def load(self, data: Any):
+        self._con.executescript(data)
+        self.init_db()
+
+    def close(self):
+        self._con.close()
+
+
+def row_factory(cur, d):
+    return SqlPoint(*d)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "connectorx>=0.4.2",
     "pyarrow>=19.0.1",
 ]
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.14"
 readme = "README.md"
 license = {text = "MIT"}
 

--- a/tests/fixtures/writer.py
+++ b/tests/fixtures/writer.py
@@ -1,10 +1,11 @@
 import pytest
 from ml_instrumentation.Writer import Writer
+from ml_instrumentation.backends.sqlite import Sqlite
 
 @pytest.fixture
 def writer():
     writer = Writer(
-        db_path=':memory:',
+        backend=Sqlite(':memory:'),
         low_watermark=2,
         high_watermark=4,
     )

--- a/tests/integration/test_Writer.py
+++ b/tests/integration/test_Writer.py
@@ -3,6 +3,8 @@ import sqlite3
 from ml_instrumentation.Writer import Point, SqlPoint, Writer
 from multiprocessing.pool import Pool
 
+from ml_instrumentation.backends.sqlite import Sqlite
+
 def test_write1(writer):
     d = Point(
         metric='measurement-1',
@@ -58,11 +60,11 @@ def test_write2(writer):
 
 def test_merge1(tmp_path):
     w1 = Writer(
-        db_path=str(tmp_path / 'w1.db'),
+        backend=Sqlite(tmp_path / 'w1.db'),
     )
 
     w2 = Writer(
-        db_path=':memory:',
+        backend=Sqlite(':memory:'),
     )
 
     for i in range(10):
@@ -117,7 +119,9 @@ def test_merge_parallel1(tmp_path):
 
 
 def _test_merge_parallel1(i: int, tmp_path):
-    writer = Writer(db_path=str(tmp_path / f'w{i}.db'))
+    writer = Writer(
+        backend=Sqlite(tmp_path / f'w{i}.db'),
+    )
 
     for j in range(100):
         writer.write(Point(exp_id=i, metric='a', frame=j, data=2*j + i))

--- a/tests/test_Writer.py
+++ b/tests/test_Writer.py
@@ -1,8 +1,9 @@
 from ml_instrumentation.Writer import Writer, Point
+from ml_instrumentation.backends.sqlite import Sqlite
 
 def test_write1():
     writer = Writer(
-        db_path=':memory:',
+        backend=Sqlite(':memory:'),
         low_watermark=2,
         high_watermark=4,
     )
@@ -39,7 +40,7 @@ def test_write1():
 
 def test_write2():
     writer = Writer(
-        db_path=':memory:',
+        backend=Sqlite(':memory:'),
         low_watermark=256,
         high_watermark=512,
     )


### PR DESCRIPTION
This should have no observable functionality changes, however it makes it possible to implement more writer backends in the future. Namely looking to add a postgresql / tsdb backend for having a centralized single DB for multiple experiments.

This is using the dependency inversion principle to have a buffered writer receive a backend, which also helps with maintainability --- buffering is now composable with arbitrary writers. Will probably need to iron out the API a little more while writing the second consumer, but this okay since it's entirely an internal API.