### PR TITLE
Support TSDB backend

### DIFF
--- a/.github/workflows/main_benchmark.yml
+++ b/.github/workflows/main_benchmark.yml
@@ -25,7 +25,7 @@ jobs:
 
       - run: |
           uv venv
-          uv sync --group=jax
+          uv sync --group=jax --group=tsdb
 
       - run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/pr_benchmark.yml
+++ b/.github/workflows/pr_benchmark.yml
@@ -20,7 +20,7 @@ jobs:
 
       - run: |
           uv venv
-          uv sync --group=jax
+          uv sync --group=jax --group=tsdb
 
       - run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -24,7 +24,7 @@ jobs:
 
       - run: |
           uv venv
-          uv sync --group=jax
+          uv sync --group=jax --group=tsdb
 
       - run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -17,7 +17,7 @@ jobs:
 
       - run: |
           uv venv
-          uv sync --group=jax
+          uv sync --group=jax --group=tsdb
 
       - run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
 

--- a/ml_instrumentation/Collector.py
+++ b/ml_instrumentation/Collector.py
@@ -33,7 +33,6 @@ class Collector:
 
         self._backend = backend or Sqlite(tmp_file)
 
-        self._tmp_file = tmp_file
         self._writer = Writer(
             backend=self._backend,
             low_watermark=low_watermark,
@@ -166,7 +165,7 @@ class Collector:
         self._writer.sync_now()
 
         data = None
-        if self._tmp_file.startswith(':memory:'):
+        if isinstance(self._backend, Sqlite) and self._backend.is_in_memory():
             data = self._writer.dump()
 
         ignore_keys = ['_writer']
@@ -182,9 +181,9 @@ class Collector:
             self.__dict__[k] = v
 
         self._writer = Writer(
-            backend=Sqlite(self._tmp_file),
-            low_watermark=1024,
-            high_watermark=2048,
+            backend=self._backend,
+            low_watermark=1_000,
+            high_watermark=100_000,
         )
 
         if state['data'] is not None:

--- a/ml_instrumentation/backends/tsdb.py
+++ b/ml_instrumentation/backends/tsdb.py
@@ -11,6 +11,7 @@ class TSDB(BaseBackend):
     def __init__(self, conninfo: str):
         import psycopg
 
+        self._conninfo = conninfo
         self._con = psycopg.connect(conninfo)
         self._con.row_factory = row_factory
 
@@ -97,6 +98,18 @@ class TSDB(BaseBackend):
 
     def close(self):
         self._con.close()
+
+    def __getstate__(self) -> object:
+        self.close()
+        return {
+            'conninfo': self._conninfo,
+        }
+
+    def __setstate__(self, state: dict[str, Any]):
+        import psycopg
+        self._conninfo = state['conninfo']
+        self._con = psycopg.connect(self._conninfo)
+        self._con.row_factory = row_factory
 
 
 def row_factory(cur):

--- a/ml_instrumentation/backends/tsdb.py
+++ b/ml_instrumentation/backends/tsdb.py
@@ -1,0 +1,106 @@
+import logging
+from typing import Any
+from ml_instrumentation.backends.base import BaseBackend, Point, SqlPoint
+import ml_instrumentation._utils.sqlite as sqlu
+
+logger = logging.getLogger('ml-instrumentation')
+
+
+
+class TSDB(BaseBackend):
+    def __init__(self, conninfo: str):
+        import psycopg
+
+        self._con = psycopg.connect(conninfo)
+        self._con.row_factory = row_factory
+
+        self._built = set[str]()
+
+
+    # -----------
+    # -- Setup --
+    # -----------
+    def init_db(self) -> None:
+        cur = self._con.cursor()
+        res = cur.execute("""
+            SELECT table_name FROM information_schema.tables;
+        """)
+        self._built = set(r[0] for r in res.fetchall())
+
+
+    def _setup_table(self):
+        if 'results' in self._built:
+            return
+
+        cur = self._con.cursor()
+        cur.execute("""
+            CREATE TABLE results (
+                time TIMESTAMP WITH TIME ZONE NOT NULL,
+                step INTEGER NOT NULL,
+                metric TEXT NOT NULL,
+                id INTEGER NOT NULL,
+                measurement DOUBLE PRECISION NOT NULL
+            );
+            SELECT create_hypertable('results', 'time', chunk_time_interval => INTERVAL 1d);
+            CREATE INDEX IF NOT EXISTS results_metric_idx ON results (metric);
+            CREATE INDEX IF NOT EXISTS results_id_idx ON results (id);
+            ALTER TABLE results SET (
+                timescaledb.compress,
+                timescaledb.compress_segmentby='metric'
+            );
+        """)
+
+    # -------------
+    # -- Reading --
+    # -------------
+    def get_tables(self):
+        return self._built
+
+    def read_metric(self, metric: str, exp_id: int | str | None = None):
+        cond = ''
+        if exp_id is not None:
+            cond = f'WHERE id={sqlu.maybe_quote(exp_id)}'
+
+        cur = self._con.cursor()
+        try:
+            query: Any = f'SELECT * FROM results {cond}'
+            cur = cur.execute(query)
+            res: list[Any] = cur.fetchall()
+        except Exception:
+            logger.warning(f'Specified metric/exp_id does not exist: <{metric}, {exp_id}>')
+            res = []
+
+        return res
+
+    # -------------
+    # -- Writing --
+    # -------------
+    def write_many(self, points: dict[str, dict[int, Point]]):
+        cur = self._con.cursor()
+        self._setup_table()
+
+        for m, sub in points.items():
+            for exp_id, p in sub.items():
+                cur.executemany('INSERT INTO results (time, step, metric, id, measurement) VALUES (now(), ?, ?, ?, ?)', [(p.frame, m, exp_id, p.data)])
+
+        self._con.commit()
+
+    # ---------------
+    # -- Lifecycle --
+    # ---------------
+
+    def dump(self) -> str:
+        raise Exception('Dump is not possible for TSDB backend')
+
+    def load(self, data: Any):
+        self.init_db()
+
+    def close(self):
+        self._con.close()
+
+
+def row_factory(cur):
+    def _inner(d):
+        return SqlPoint(*d)
+
+    return _inner

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ dev = [
     "pytest-cov>=6.0.0",
     "ruff>=0.9.5",
 ]
+tsdb = [
+    "psycopg>=3.2.6",
+]
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
Adds support for timescaledb as a backend storage host for metrics. This uses a slightly different schema due to the differences in performance between TSDB and sqlite3.

Here we use a "tall" format (or melt format) with the metric name being a column for each data point. This is notably less memory efficient, however TSDB's compression is pretty good at handling it.