### PR TITLE
Touchups

### DIFF
--- a/ml_instrumentation/Collector.py
+++ b/ml_instrumentation/Collector.py
@@ -175,7 +175,7 @@ class Collector:
             },
         }
 
-    def __setstate__(self, state):
+    def __setstate__(self, state: dict[str, Any]):
         for k, v in state['sub'].items():
             self.__dict__[k] = v
 

--- a/ml_instrumentation/Sampler.py
+++ b/ml_instrumentation/Sampler.py
@@ -1,5 +1,5 @@
-from collections.abc import Callable
 import numpy as np
+from collections.abc import Callable
 
 class Sampler:
     def next(self, v: float) -> float | None: ...
@@ -8,8 +8,8 @@ class Sampler:
 
 class Ignore:
     def __init__(self): ...
-    def next(self, v): return None
-    def next_eval(self, v): return None
+    def next(self, v: float): return None
+    def next_eval(self, v: Callable[[], float]): return None
     def end(self): return None
 
 # by definition, this must be a stateless object

--- a/ml_instrumentation/backends/sqlite.py
+++ b/ml_instrumentation/backends/sqlite.py
@@ -1,9 +1,9 @@
-from pathlib import Path
-from typing import Any
-import filelock
 import logging
 import os
 import sqlite3
+from pathlib import Path
+from typing import Any
+import filelock
 from ml_instrumentation.backends.base import BaseBackend, Point, SqlPoint
 import ml_instrumentation._utils.sqlite as sqlu
 
@@ -138,5 +138,5 @@ class Sqlite(BaseBackend):
         self._built = set[str]()
 
 
-def row_factory(cur, d):
+def row_factory(cur: sqlite3.Cursor, d: tuple[Any, ...]):
     return SqlPoint(*d)

--- a/ml_instrumentation/metadata.py
+++ b/ml_instrumentation/metadata.py
@@ -2,15 +2,16 @@ import sqlite3
 from pathlib import Path
 from typing import Any
 
-from filelock import FileLock
+from filelock import FileLock, BaseFileLock
 
 import ml_instrumentation._utils.sqlite as sqlu
 
-def attach_metadata(db_path: str | Path, id: int | str, metadata: dict[str, Any]):
+def attach_metadata(db_path: str | Path, id: int | str, metadata: dict[str, Any], lock: BaseFileLock | None = None):
     db_path = Path(db_path)
     db_path.parent.mkdir(parents=True, exist_ok=True)
 
-    with FileLock(f'{db_path}.lock'):
+    lock = lock if lock is not None else FileLock(f'{db_path}.lock')
+    with lock:
         con = sqlite3.connect(db_path)
         cur = con.cursor()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,22 @@ include = ['ml_instrumentation', 'tests']
 venvPath = '.'
 venv = '.venv'
 typeCheckingMode = 'standard'
+
+# common overrides
 useLibraryCodeForTypes = true
+strictListInference = true
+strictDictionaryInference = true
+strictSetInference = true
+enableReachabilityAnalysis = true
+
+# stricter overrides
+reportInconsistentConstructor = true
+reportMissingParameterType = true
+reportUnnecessaryCast = true
+reportUnnecessaryIsInstance = true
+reportUnusedClass = true
+reportUnusedExpression = true
+reportUnusedFunction = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["ml_instrumentation"]

--- a/tests/acceptance/test_Collector.py
+++ b/tests/acceptance/test_Collector.py
@@ -1,5 +1,7 @@
 import pickle
 import pytest
+from pathlib import Path
+from typing import Any
 
 from ml_instrumentation.Collector import Collector
 from tests.fixtures.collector import basic_collector, disk_collector, simulate_run, SimMetric
@@ -16,7 +18,7 @@ User should be able to:
 The above should be able to run with in-memory collection and disk-backed collection.
 """
 @pytest.mark.parametrize('collector_fixture', [basic_collector, disk_collector])
-def test_collector1(collector_fixture, tmp_path, request):
+def test_collector1(collector_fixture: Any, tmp_path: Path, request: pytest.FixtureRequest):
     collector: Collector = request.getfixturevalue(collector_fixture.__name__)
     collector.set_experiment_id(0)
 

--- a/tests/fixtures/collector.py
+++ b/tests/fixtures/collector.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable, Sequence
 import pytest
+from pathlib import Path
 from collections import defaultdict
 from typing import Any, NamedTuple
 from ml_instrumentation.Collector import Collector
@@ -21,7 +22,7 @@ def basic_collector():
 
 
 @pytest.fixture
-def disk_collector(tmp_path):
+def disk_collector(tmp_path: Path):
     c = Collector(
         tmp_file=str(tmp_path / 'test.db'),
         config = {

--- a/tests/integration/test_Collector.py
+++ b/tests/integration/test_Collector.py
@@ -2,7 +2,7 @@ import pickle
 from ml_instrumentation.Collector import Collector
 from ml_instrumentation.Writer import SqlPoint
 
-def test_collector_rw1(basic_collector):
+def test_collector_rw1(basic_collector: Collector):
     basic_collector.set_experiment_id(0)
     basic_collector.next_frame()
 
@@ -23,7 +23,7 @@ def test_collector_rw1(basic_collector):
         SqlPoint(frame=1, id=0, measurement=1),
     ]
 
-def test_collector_rw_trailing_edge1(basic_collector):
+def test_collector_rw_trailing_edge1(basic_collector: Collector):
     basic_collector.set_experiment_id(0)
 
     # note: no next_frame call here, it will go after
@@ -43,7 +43,7 @@ def test_collector_rw_trailing_edge1(basic_collector):
     ]
 
 
-def test_collector_serde(basic_collector):
+def test_collector_serde(basic_collector: Collector):
     basic_collector.set_experiment_id(0)
     basic_collector.next_frame()
 

--- a/tests/integration/test_Writer.py
+++ b/tests/integration/test_Writer.py
@@ -1,11 +1,12 @@
-from functools import partial
 import sqlite3
+from functools import partial
+from pathlib import Path
 from ml_instrumentation.Writer import Point, SqlPoint, Writer
 from multiprocessing.pool import Pool
 
 from ml_instrumentation.backends.sqlite import Sqlite
 
-def test_write1(writer):
+def test_write1(writer: Writer):
     d = Point(
         metric='measurement-1',
         exp_id=0,
@@ -34,7 +35,7 @@ def test_write1(writer):
         SqlPoint(1, 0, 2.2),
     ]
 
-def test_write2(writer):
+def test_write2(writer: Writer):
     for i in range(1_000):
         d = Point(
             metric='measurement-1',
@@ -58,7 +59,7 @@ def test_write2(writer):
     assert len(points) == 334
 
 
-def test_merge1(tmp_path):
+def test_merge1(tmp_path: Path):
     w1 = Writer(
         backend=Sqlite(tmp_path / 'w1.db'),
     )
@@ -95,7 +96,7 @@ def test_merge1(tmp_path):
     w2.close()
 
 
-def test_merge_parallel1(tmp_path):
+def test_merge_parallel1(tmp_path: Path):
     pool = Pool(10)
     pool.map(partial(_test_merge_parallel1, tmp_path=tmp_path), range(20))
 
@@ -118,7 +119,7 @@ def test_merge_parallel1(tmp_path):
     assert len(res) == 20 * 100
 
 
-def _test_merge_parallel1(i: int, tmp_path):
+def _test_merge_parallel1(i: int, tmp_path: Path):
     writer = Writer(
         backend=Sqlite(tmp_path / f'w{i}.db'),
     )

--- a/tests/performance/test_Collector.py
+++ b/tests/performance/test_Collector.py
@@ -1,10 +1,11 @@
 import pytest
+from typing import Any
 from tests.fixtures.collector import basic_collector, disk_collector
 
 from ml_instrumentation.Collector import Collector
 
 @pytest.mark.parametrize('collector_fixture', [basic_collector, disk_collector])
-def test_benchmark_write_path1(collector_fixture, request, benchmark):
+def test_benchmark_write_path1(collector_fixture: Any, request: pytest.FixtureRequest, benchmark: Any):
     collector: Collector = request.getfixturevalue(collector_fixture.__name__)
     collector.set_experiment_id(0)
 
@@ -22,7 +23,7 @@ def test_benchmark_write_path1(collector_fixture, request, benchmark):
     benchmark(_inner)
 
 @pytest.mark.parametrize('collector_fixture', [basic_collector, disk_collector])
-def test_benchmark_read1(collector_fixture, request, benchmark):
+def test_benchmark_read1(collector_fixture: Any, request: pytest.FixtureRequest, benchmark: Any):
     collector: Collector = request.getfixturevalue(collector_fixture.__name__)
     collector.set_experiment_id(0)
     for i in range(1_000):

--- a/tests/unit/test_Collector.py
+++ b/tests/unit/test_Collector.py
@@ -1,4 +1,6 @@
-def test_collector_setup1(basic_collector):
+from ml_instrumentation.Collector import Collector
+
+def test_collector_setup1(basic_collector: Collector):
     assert basic_collector.keys() == set()
     assert basic_collector.experiment_ids() == set()
 


### PR DESCRIPTION
Adds a minor fix to make data loading more robust to `Null` values in the `_metadata_` table. By default, connectorx does not try to figure out the type of a column when the first row is null unless the table is split into multiple partitions. Since this table is small, we can ignore performance concerns and just split into many singleton partitions to (nearly) guarantee a non-null value is found.

PR also adds a way to pass an existing file lock to the `attach_metadata` method, allowing this method to be used to claim unique identifiers without concern of deadlocking.